### PR TITLE
Better error handling

### DIFF
--- a/src/components/wallet.ts
+++ b/src/components/wallet.ts
@@ -62,6 +62,8 @@ export default class Wallet implements WalletInterface {
     inputAsset: string,
     outputAsset: string
   ): string {
+    if (inputs.length === 0) throw new Error('Swap: No utxos available');
+
     let psbt: Psbt;
     try {
       psbt = Psbt.fromBase64(psbtBase64);
@@ -116,6 +118,8 @@ export default class Wallet implements WalletInterface {
   }
 
   payFees(psbtBase64: string, utxos: any[]): string {
+    if (utxos.length === 0) throw new Error('Fees: No utxos available');
+
     const psbt = Psbt.fromBase64(psbtBase64);
     const tx = Transaction.fromBuffer(psbt.data.getTransaction());
     const { fees } = calculateFees(tx.ins.length + 1, tx.outs.length + 2);

--- a/src/utils/coinselect.ts
+++ b/src/utils/coinselect.ts
@@ -71,7 +71,8 @@ export function coinselect(utxos, amount) {
     if (availableSat >= amount) break;
   }
 
-  if (availableSat < amount) throw 'You do not have enough in your wallet';
+  if (availableSat < amount)
+    throw new Error('You do not have enough in your wallet');
 
   change = availableSat - amount;
 


### PR DESCRIPTION
 Before this commit, we wouldn't have thrown an `Error` in `coinselection` function and we never check if the array of utxos passed to `updateTx` and `payFees` were empty .

This way we could distinguish when the balance is 0 (not initialized) or if it has been consumed by swaps and need to be refilled.